### PR TITLE
Preliminary Mach3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcmc_diagnostics
 
-A small package for running MCMC diagnostics on Aria and/or Stan chains. Can be used for:
+A small package for running MCMC diagnostics on Aria, Stan or MaCh3 (experimental) chains. Can be used for:
 
 1. Removing the burin-in
 2. Getting the effective sample size
@@ -32,7 +32,7 @@ For help, simply run
 
 ### Best practices for diagnostics
 
-The MCMC diagnostics should always be run in two stages, whether running on `Stan` or `Aria` MCMC chains:
+The MCMC diagnostics should always be run in two stages, whether running on `Stan`, `Aria` or `MaCh3` (experimental) MCMC chains:
 
 #### 1. Find the appropriate burn-in
 

--- a/diagnostics/sampler_metadata.py
+++ b/diagnostics/sampler_metadata.py
@@ -6,6 +6,9 @@ BRANCH_KEYWORDS_STAN = ["logprob", "Th13", "Th23", "dCP", "DmSq32"]
 IGNORE_BRANCHES_ARIA = ["MH", "stepnum"]
 BRANCHES_KEYWORDS_ARIA = ["logprob", "th13", "th23", "delta(pi)", "dmsq32"]
 
+IGNORE_BRANCHES_MACH3 = ["accProb", "step", "stepTime", "LogL_sample_0", "LogL_systematic_osc_cov", "LogL_systematic_xsec_cov"]
+BRANCHES_KEYWORDS_MACH3 = ["LogL", "sin2th_13", "sin2th_23", "delta_cp", "delm2_23", "sin2th_12", "delm2_12"]
+
 class SamplerMetadata:
     """
     Class to hold metadata for a sampler.
@@ -56,6 +59,8 @@ class SamplerMetadata:
             return 200
         elif self.sampler_name == "aria":
             return 20_000
+        elif self.sampler_name == "mach3":
+            return 40_000
         else:
             raise ValueError("Unknown sampler type. Please check the files.")
 
@@ -72,6 +77,11 @@ class SamplerMetadata:
                 self.ignored_branches = IGNORE_BRANCHES_ARIA
                 self.key_branches = BRANCHES_KEYWORDS_ARIA
                 self.ttree_location = "run/samples"
+            elif "posteriors":
+                self.sampler_name = "mach3"
+                self.ignored_branches = IGNORE_BRANCHES_MACH3
+                self.key_branches = BRANCHES_KEYWORDS_MACH3
+                self.ttree_location = "posteriors"
             else:
                 raise ValueError("Unknown sampler type. Please check the files.")
 


### PR DESCRIPTION
Adding preliminary MaCh3 support for mcmc_diagnostics.

It is preliminary because there are still a few things to do:
1. Making sure all the `LogL_sample` `LogL_systematic` are masked out, not just the few hard-coded ones. This has to be done through a wildcard
2. Using the `step` branch for the diagnostics where it matters, including traces, autocorrelations etc. This is also true for Stan and Aria (more so for Aria).

And of course looking for any bugs/issues etc.